### PR TITLE
Fix up log messages with mixed up dates

### DIFF
--- a/freezing/sync/data/activity.py
+++ b/freezing/sync/data/activity.py
@@ -358,8 +358,8 @@ class ActivitySync(BaseSync):
                 "Skipping ride {0} ({1!r}) because date ({2}) is before competition start date ({3})".format(
                     activity.id,
                     activity.name,
-                    start_date,
-                    end_date))
+                    activity_start_date,
+                    start_date))
 
         if end_date and activity_end_date > end_date:
             raise IneligibleActivity(

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ except ImportError:  # for pip <= 9.0.3
 
 from setuptools import setup
 
-version = '1.1.0'
+version = '1.1.1'
 
 long_description = """
 freezing-sync is the component responsible for fetching activities, weather data, etc.


### PR DESCRIPTION
The activity dates in the log messages where activities get ignored before the competition begins were showing the wrong dates. This fixes that: 

```
INFO     [freezing.sync.autolog.AutoLogger] Skipping ride 2047673084 ('London') because date (2019-01-01 00:00:00-05:00) is before competition start date (2019-03-21 00:01:00-04:00)
```