### PR TITLE
Switch to deadsnakes python ppas

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,13 +2,13 @@
 # =====
 
 FROM ubuntu:xenial as buildstep
-LABEL maintainer="Hans Lellelid <hans@xmpl.org>"
+LABEL maintainer="Richard Bullington-McGuire <richard@obscure.org>"
 
 COPY resources/docker/sources.list /etc/apt/sources.list
 RUN apt-get update
 
 RUN apt-get install -y software-properties-common
-RUN add-apt-repository -y ppa:jonathonf/python-3.6
+RUN add-apt-repository -y ppa:deadsnakes/ppa
 RUN apt-get update
 
 RUN apt-get install -y python3.6 python3.6-dev curl build-essential git
@@ -32,15 +32,15 @@ RUN python3.6 setup.py bdist_wheel -d /build/wheels
 # =====
 
 FROM ubuntu:xenial as deploystep
-LABEL maintainer="Hans Lellelid <hans@xmpl.org>"
+LABEL maintainer="Richard Bullington-McGuire <richard@obscure.org>"
 
 COPY resources/docker/sources.list /etc/apt/sources.list
 
 RUN apt-get update \
   && apt-get install -y software-properties-common curl \
-  && add-apt-repository -y ppa:jonathonf/python-3.6 \
+  && add-apt-repository -y ppa:deadsnakes/ppa \
   && apt-get update \
-  && apt-get install -y python3.6 vim-tiny --no-install-recommends \
+  && apt-get install -y python3.6 --no-install-recommends \
   && apt-get clean \
   && curl https://bootstrap.pypa.io/get-pip.py | python3.6 \
   && pip3 install --upgrade pip setuptools wheel \

--- a/freezing/sync/subscribe.py
+++ b/freezing/sync/subscribe.py
@@ -74,7 +74,7 @@ class ActivityUpdateSubscriber:
                 else:
                     try:
                         self.logger.info("Received message: {!r}".format(job.body))
-                        update = schema.loads(job.body).data
+                        update = schema.loads(job.body)
                         self.handle_message(update)
                     except:
                         self.logger.exception("Error procesing message, will requeue w/ delay.")

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,6 @@ PyMySQL==0.8.0
 polyline==1.3.2
 colorlog==3.1.0
 -e git+https://github.com/hozn/GeoAlchemy@0.7.3dev1#egg=GeoAlchemy
--e git+https://github.com/freezingsaddles/freezing-model@0.3.7#egg=freezing-model
+-e git+https://github.com/freezingsaddles/freezing-model@0.5.0#egg=freezing-model
 APScheduler==3.5.1
 datadog==0.18.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
 envparse==0.2.0
-greenstalk==0.5.0
-stravalib>=0.9.1
-PyMySQL==0.8.0
-polyline==1.3.2
-colorlog==3.1.0
+greenstalk==1.0.1
+stravalib>=0.10.2
+PyMySQL==0.9.3
+polyline==1.4.0
+colorlog==4.1.0
 -e git+https://github.com/hozn/GeoAlchemy@0.7.3dev1#egg=GeoAlchemy
 -e git+https://github.com/freezingsaddles/freezing-model@0.5.0#egg=freezing-model
-APScheduler==3.5.1
-datadog==0.18.0
+APScheduler==3.6.3
+datadog==0.33.0


### PR DESCRIPTION
Ugh, the `ppa:jonathonf/python-3.6` repos went away:

https://www.reddit.com/r/linux/comments/eamh3n/jonathon_f_removed_his_popular_ppas_from_public/

deadsnakes to the rescue.