### PR TITLE
Keep display names stable

### DIFF
--- a/freezing/sync/data/activity.py
+++ b/freezing/sync/data/activity.py
@@ -268,7 +268,7 @@ class ActivitySync(BaseSync):
         else:
             self.logger.warning("Unable to find ride {} for athlete {} to remove.".format(activity_id, athlete_id))
 
-    def fetch_and_store_actvitiy_detail(self, *, athlete_id: int, activity_id:int, use_cache: bool = False):
+    def fetch_and_store_activity_detail(self, *, athlete_id: int, activity_id:int, use_cache: bool = False):
 
         with meta.transaction_context() as session:
 

--- a/freezing/sync/data/athlete.py
+++ b/freezing/sync/data/athlete.py
@@ -79,23 +79,17 @@ class AthleteSync(BaseSync):
                        .filter(Athlete.display_name == display_name) \
                        .count() > 0
 
-        def unambiguous_display_name(idx: int) -> str:
-            name = athlete_name[:idx]
-            return name if name == athlete_name or \
-                len(athlete_name) == idx or \
-                not already_exists(name) \
-                else unambiguous_display_name(idx + 1)
+        def unambiguous_display_name() -> str:
+            display_name = athlete_name[2 + athlete_name.index(' ')]
+            return display_name \
+                if not already_exists(display_name) \
+                else athlete_name
 
         # Only update the display name if it is either:
-        # a new athlete, or
-        # the athlete name has changed, and
-        #   the original display name still matches the original strava name
+        # a new athlete, or the athlete name has changed
         try:
-            if athlete is None or \
-                athlete_name != athlete.name and \
-                    athlete.name.startswith(athlete.display_name):
-                    athlete.display_name = unambiguous_display_name(
-                            2 + athlete_name.index(' '))
+            if athlete is None or athlete_name != athlete.name:
+                athlete.display_name = unambiguous_display_name()
         except:
             self.logger.exception(
                 "Athlete name disambiguation error for {}".format(

--- a/freezing/sync/data/athlete.py
+++ b/freezing/sync/data/athlete.py
@@ -34,11 +34,11 @@ class AthleteSync(BaseSync):
 
         with meta.transaction_context() as sess:
 
-            # We iterate over all of our athletes that have access tokens.  (We can't fetch anything
-            # for those that don't.)
+            # We iterate over all of our athletes that have access tokens.
+            # (We can't fetch anything for those that don't.)
 
             q = sess.query(Athlete)
-            q = q.filter(Athlete.access_token != None)
+            q = q.filter(Athlete.access_token is not None)
             if max_records:
                 self.logger.info("Limiting to {} records.".format(max_records))
                 q = q.limit(max_records)
@@ -52,13 +52,10 @@ class AthleteSync(BaseSync):
                     self.register_athlete_team(strava_athlete, athlete)
                 except:
                     self.logger.warning("Error registering athlete {0}".format(athlete), exc_info=True)
-                    # But carry on
 
-            # Disable disambiguation because it overwrites custom display names. register_athlete()
-            # already makes an effort to disambiguate names, so it seems somewhat redundant anyway.
-            # self.disambiguate_athlete_display_names()
-
-    def register_athlete(self, strava_athlete: sm.Athlete, access_token: str) -> Athlete:
+    def register_athlete(self,
+                         strava_athlete: sm.Athlete,
+                         access_token: str) -> Athlete:
         """
         Ensure specified athlete is added to database, returns athlete model.
 
@@ -68,17 +65,12 @@ class AthleteSync(BaseSync):
         session = meta.scoped_session()
         athlete = session.query(Athlete).get(strava_athlete.id)
 
-        # Only update the display name if it's either a new athlete or the athlete name has
-        # changed and the original display name still matches the original strava name
-        athlete_name = f'{strava_athlete.firstname} {strava_athlete.lastname}'
-        generate_display_name = athlete is None or \
-            athlete_name != athlete.name and athlete.name.startswith(athlete.display_name)
-
         if athlete is None:
             athlete = Athlete()
 
         athlete.id = strava_athlete.id
-        athlete.name = athlete_name
+        athlete_name = \
+            f'{strava_athlete.firstname} {strava_athlete.lastname}'
         athlete.profile_photo = strava_athlete.profile
         athlete.access_token = access_token
 
@@ -89,72 +81,31 @@ class AthleteSync(BaseSync):
 
         def unambiguous_display_name(idx: int) -> str:
             name = athlete_name[:idx]
-            return name if name == athlete_name or not already_exists(name) else unambiguous_display_name(idx + 1)
+            return name if name == athlete_name or \
+                len(athlete_name) == idx or \
+                not already_exists(name) \
+                else unambiguous_display_name(idx + 1)
 
-        if generate_display_name:
-            athlete.display_name = unambiguous_display_name(2 + athlete_name.index(' '))
-
-        session.add(athlete)
-
+        # Only update the display name if it is either:
+        # a new athlete, or
+        # the athlete name has changed, and
+        #   the original display name still matches the original strava name
+        try:
+            if athlete is None or \
+                athlete_name != athlete.name and \
+                    athlete.name.startswith(athlete.display_name):
+                    athlete.display_name = unambiguous_display_name(
+                            2 + athlete_name.index(' '))
+        except:
+            self.logger.exception(
+                "Athlete name disambiguation error for {}".format(
+                    strava_athlete.id),
+                exc_info=True)
+            athlete.display_name = athlete_name
+        finally:
+            session.add(athlete)
         return athlete
 
-    # Presently disabled.
-    def disambiguate_athlete_display_names(self):
-        session = meta.scoped_session()
-        q = session.query(Athlete)
-        q = q.filter(Athlete.access_token != None)
-        athletes = q.all()
-
-        # Ok, here is the plan; bin these things together based on firstname and last initial.
-        # Then iterate over each bin and if there are multiple entries, find the least number
-        # of letters to make them all different. (we should be able to use set intersection
-        # to check for differences within the bins?)
-
-        def firstlast(name):
-            name_parts = a.name.split(' ')
-            fname = name_parts[0]
-            if len(name_parts) < 2:
-                lname = None
-            else:
-                lname = name_parts[-1]
-            return (fname, lname)
-
-        athletes_bin = {}
-        for a in athletes:
-            (fname, lname) = firstlast(a.name)
-            if lname is None:
-                # We only care about people with first and last names for this exercise
-                # key = fname
-                continue
-            else:
-                key = '{0} {1}'.format(fname, lname[0])
-            athletes_bin.setdefault(key, []).append(a)
-
-        for (name_key, athletes) in athletes_bin.items():
-            shortest_lname = min([firstlast(a.name)[1] for a in athletes], key=len)
-            required_length = None
-            for i in range(len(shortest_lname)):
-                # Calculate fname + lname-of-x-chars for each athlete.
-                # If unique, then use this number and update the model objects
-                candidate_short_lasts = [firstlast(a.name)[1][:i + 1] for a in athletes]
-                if len(set(candidate_short_lasts)) == len(candidate_short_lasts):
-                    required_length = i + 1
-                    break
-
-            if required_length is not None:
-                for a in athletes:
-                    fname, lname = firstlast(a.name)
-                    self.logger.debug("Converting '{fname} {lname}' "
-                                      "-> '{fname} {minlname}".format(fname=fname,
-                                                                      lname=lname,
-                                                                      minlname=lname[:required_length]))
-                    a.display_name = '{0} {1}'.format(fname, lname[:required_length])
-            else:
-                self.logger.debug("Unable to find a minimum lastname; using full lastname.")
-                # Just use full names
-                for a in athletes:
-                    fname, lname = firstlast(a.name)
-                    a.display_name = '{0} {1}'.format(fname, lname[:required_length])
 
     def register_athlete_team(self, strava_athlete:sm.Athlete, athlete_model:Athlete) -> Team:
         """

--- a/freezing/sync/subscribe.py
+++ b/freezing/sync/subscribe.py
@@ -44,13 +44,13 @@ class ActivityUpdateSubscriber:
 
                 elif message.operation is AspectType.update:
                     statsd.increment('strava.activity.update', tags=['team:{}'.format(athlete.team_id)])
-                    self.activity_sync.fetch_and_store_actvitiy_detail(athlete_id=message.athlete_id,
+                    self.activity_sync.fetch_and_store_activity_detail(athlete_id=message.athlete_id,
                                                                        activity_id=message.activity_id)
                     # (We'll assume the stream doens't need re-fetching.)
 
                 elif message.operation is AspectType.create:
                     statsd.increment('strava.activity.create', tags=['team:{}'.format(athlete.team_id)])
-                    self.activity_sync.fetch_and_store_actvitiy_detail(athlete_id=message.athlete_id,
+                    self.activity_sync.fetch_and_store_activity_detail(athlete_id=message.athlete_id,
                                                                        activity_id=message.activity_id)
                     self.streams_sync.fetch_and_store_activity_streams(athlete_id=message.athlete_id,
                                                                        activity_id=message.activity_id)


### PR DESCRIPTION
Only update athlete display name if either they are a new athlete, or an existing athlete with a new athlete name and the old display name still matches the old athlete name. Closes #16. Hypothetical and untested, must learn to test strava sync.