### PR TITLE
Requeue failed Strava sync messages after 5 minutes to avoid server overload

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,58 +1,20 @@
-# BUILD
-# =====
-
-FROM ubuntu:xenial as buildstep
+FROM python:3.7-alpine
 LABEL maintainer="Richard Bullington-McGuire <richard@obscure.org>"
-
-COPY resources/docker/sources.list /etc/apt/sources.list
-RUN apt-get update
-
-RUN apt-get install -y software-properties-common
-RUN add-apt-repository -y ppa:deadsnakes/ppa
-RUN apt-get update
-
-RUN apt-get install -y python3.6 python3.6-dev curl build-essential git
-
-RUN mkdir -p /build/wheels
-RUN curl https://bootstrap.pypa.io/get-pip.py | python3.6
-
-RUN pip3 install --upgrade pip setuptools wheel
-
+RUN apk update
+RUN apk add py3-mysqlclient git build-base
+RUN addgroup -S freezing && adduser -S -G freezing freezing
+RUN pip3 install --upgrade pip
 ADD requirements.txt /tmp/requirements.txt
-RUN pip3 wheel -r /tmp/requirements.txt --wheel-dir=/build/wheels
-
-# Now build the wheel for this project too.
+RUN pip3 install -r /tmp/requirements.txt
+RUN apk del git build-base
 ADD . /app
 WORKDIR /app
 
-RUN python3.6 setup.py bdist_wheel -d /build/wheels
-
-
-# DEPLOY
-# =====
-
-FROM ubuntu:xenial as deploystep
-LABEL maintainer="Richard Bullington-McGuire <richard@obscure.org>"
-
-COPY resources/docker/sources.list /etc/apt/sources.list
-
-RUN apt-get update \
-  && apt-get install -y software-properties-common curl \
-  && add-apt-repository -y ppa:deadsnakes/ppa \
-  && apt-get update \
-  && apt-get install -y python3.6 --no-install-recommends \
-  && apt-get clean \
-  && curl https://bootstrap.pypa.io/get-pip.py | python3.6 \
-  && pip3 install --upgrade pip setuptools wheel \
-  && rm -rf /var/lib/apt/lists/*
-
 RUN mkdir -p /data/cache/activities
 RUN mkdir -p /data/cache/weather
+RUN chown freezing:freezing /data/cache/activities
 
 VOLUME /data
-
-COPY --from=buildstep /build/wheels /tmp/wheels
-
-RUN pip3 install /tmp/wheels/*
-
+# We should activate this - but need to make sure the cache still works
+#USER freezing
 CMD freezing-sync

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get install -y software-properties-common
 RUN add-apt-repository -y ppa:deadsnakes/ppa
 RUN apt-get update
 
-RUN apt-get install -y python3.6 python3.6-dev curl build-essential git
+RUN apt-get install -y python3.6 python3.6-dev curl build-essential
 
 RUN mkdir -p /build/wheels
 RUN curl https://bootstrap.pypa.io/get-pip.py | python3.6

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,58 @@
-FROM python:3.7-alpine
+# BUILD
+# =====
+
+FROM ubuntu:xenial as buildstep
 LABEL maintainer="Richard Bullington-McGuire <richard@obscure.org>"
-RUN apk update
-RUN apk add py3-mysqlclient git build-base
-RUN addgroup -S freezing && adduser -S -G freezing freezing
-RUN pip3 install --upgrade pip
+
+COPY resources/docker/sources.list /etc/apt/sources.list
+RUN apt-get update
+
+RUN apt-get install -y software-properties-common
+RUN add-apt-repository -y ppa:deadsnakes/ppa
+RUN apt-get update
+
+RUN apt-get install -y python3.6 python3.6-dev curl build-essential git
+
+RUN mkdir -p /build/wheels
+RUN curl https://bootstrap.pypa.io/get-pip.py | python3.6
+
+RUN pip3 install --upgrade pip setuptools wheel
+
 ADD requirements.txt /tmp/requirements.txt
-RUN pip3 install -r /tmp/requirements.txt
-RUN apk del git build-base
+RUN pip3 wheel -r /tmp/requirements.txt --wheel-dir=/build/wheels
+
+# Now build the wheel for this project too.
 ADD . /app
 WORKDIR /app
 
+RUN python3.6 setup.py bdist_wheel -d /build/wheels
+
+
+# DEPLOY
+# =====
+
+FROM ubuntu:xenial as deploystep
+LABEL maintainer="Richard Bullington-McGuire <richard@obscure.org>"
+
+COPY resources/docker/sources.list /etc/apt/sources.list
+
+RUN apt-get update \
+  && apt-get install -y software-properties-common curl \
+  && add-apt-repository -y ppa:deadsnakes/ppa \
+  && apt-get update \
+  && apt-get install -y python3.6 --no-install-recommends \
+  && apt-get clean \
+  && curl https://bootstrap.pypa.io/get-pip.py | python3.6 \
+  && pip3 install --upgrade pip setuptools wheel \
+  && rm -rf /var/lib/apt/lists/*
+
 RUN mkdir -p /data/cache/activities
 RUN mkdir -p /data/cache/weather
-RUN chown freezing:freezing /data/cache/activities
 
 VOLUME /data
-# We should activate this - but need to make sure the cache still works
-#USER freezing
+
+COPY --from=buildstep /build/wheels /tmp/wheels
+
+RUN pip3 install /tmp/wheels/*
+
 CMD freezing-sync

--- a/freezing/sync/config.py
+++ b/freezing/sync/config.py
@@ -63,6 +63,8 @@ class Config:
     DATADOG_HOST = env("DATADOG_HOST", default="datadog.container")
     DATADOG_PORT = env("DATADOG_PORT", cast=int, default=8125)
 
+    REQUEUE_DELAY = env("REQUEUE_DELAY", cast=int, default=300)
+
 
 config = Config()
 

--- a/freezing/sync/subscribe.py
+++ b/freezing/sync/subscribe.py
@@ -97,11 +97,11 @@ class ActivityUpdateSubscriber:
                         self.handle_message(update)
                     except:
                         self.logger.exception(
-                            "Error procesing message, will requeue w/ delay."
+                            "Error processing message, will requeue w/ delay."
                         )
                         statsd.increment("strava.webhook.error")
                         self.client.release(
-                            job, delay=20
+                            job, delay=300
                         )  # We put it back with a delay
                     else:
                         self.client.delete(job)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,11 @@
 envparse==0.2.0
 greenstalk==1.0.1
-stravalib>=0.10.2
+stravalib==0.10.4
 PyMySQL==0.9.3
 polyline==1.4.0
 colorlog==4.1.0
--e git+https://github.com/hozn/GeoAlchemy@0.7.3dev1#egg=GeoAlchemy
--e git+https://github.com/freezingsaddles/freezing-model@0.5.16#egg=freezing-model
+https://github.com/hozn/GeoAlchemy/archive/0.7.3dev1.tar.gz
+https://github.com/freezingsaddles/freezing-model/archive/0.5.16.tar.gz
 APScheduler==3.6.3
 datadog==0.33.0
 requests==2.22.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ PyMySQL==0.9.3
 polyline==1.4.0
 colorlog==4.1.0
 -e git+https://github.com/hozn/GeoAlchemy@0.7.3dev1#egg=GeoAlchemy
--e git+https://github.com/freezingsaddles/freezing-model@0.5.7#egg=freezing-model
+-e git+https://github.com/freezingsaddles/freezing-model@0.5.16#egg=freezing-model
 APScheduler==3.6.3
 datadog==0.33.0
 requests==2.22.0

--- a/setup.py
+++ b/setup.py
@@ -1,13 +1,6 @@
 # -*- coding: utf-8 -*-
 import os.path
 
-# Ugh, pip 10 is backward incompatible, but there is a workaround:
-# Thanks Stack Overflow https://stackoverflow.com/a/49867265
-try:  # for pip >= 10
-    from pip._internal.req import parse_requirements
-except ImportError:  # for pip <= 9.0.3
-    from pip.req import parse_requirements
-
 from setuptools import setup
 
 version = '1.1.6'
@@ -16,19 +9,20 @@ long_description = """
 freezing-sync is the component responsible for fetching activities, weather data, etc.
 """
 
-# parse_requirements() returns generator of pip.req.InstallRequirement objects
-install_reqs = parse_requirements(os.path.join(os.path.dirname(__file__), 'requirements.txt'), session=False)
-
-# reqs is a list of requirement
-# e.g. ['django==1.5.1', 'mezzanine==1.4.6']
-# Without the try below this may fail with:
-#  AttributeError: 'ParsedRequirement' object has no attribute 'req'
-# Thanks Mehant Kammakomati and Stack Overflow for the fix: https://stackoverflow.com/a/62127548
-install_reqs=list(install_reqs)
-try:
-        reqs = [str(ir.req) for ir in install_reqs]
-except:
-        reqs = [str(ir.requirement) for ir in install_reqs]
+install_requires=[
+    "envparse",
+    "greenstalk",
+    "stravalib",
+    "PyMySQL",
+    "polyline",
+    "colorlog",
+    "GeoAlchemy",
+    "freezing-model",
+    "APScheduler",
+    "datadog",
+    "requests",
+    "pytz"
+]
 
 setup(
     name='freezing-sync',
@@ -51,7 +45,7 @@ setup(
     ],
     # include_package_data=True,
     # package_data={'stravalib': ['tests/resources/*']},
-    install_requires=reqs,
+    install_requires=install_requires,
     classifiers=[
         'Development Status :: 4 - Beta',
         'License :: OSI Approved :: Apache Software License',

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ except ImportError:  # for pip <= 9.0.3
 
 from setuptools import setup
 
-version = '1.1.5'
+version = '1.1.6'
 
 long_description = """
 freezing-sync is the component responsible for fetching activities, weather data, etc.
@@ -21,7 +21,14 @@ install_reqs = parse_requirements(os.path.join(os.path.dirname(__file__), 'requi
 
 # reqs is a list of requirement
 # e.g. ['django==1.5.1', 'mezzanine==1.4.6']
-reqs = [str(ir.req) for ir in install_reqs]
+# Without the try below this may fail with:
+#  AttributeError: 'ParsedRequirement' object has no attribute 'req'
+# Thanks Mehant Kammakomati and Stack Overflow for the fix: https://stackoverflow.com/a/62127548
+install_reqs=list(install_reqs)
+try:
+        reqs = [str(ir.req) for ir in install_reqs]
+except:
+        reqs = [str(ir.requirement) for ir in install_reqs]
 
 setup(
     name='freezing-sync',


### PR DESCRIPTION
Currently we retry after 20 seconds. So if we hit the Strava 15-minute rate limit we'll keep on retrying every 20 seconds, chipping away at the daily limit. This changes that retry to 5 minutes. Which shouldn't realistically cause any undue delay.