### PR TITLE
Freezing model 0.7 updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ FROM ubuntu:22.04 as deploystep
 LABEL maintainer="Richard Bullington-McGuire <richard@obscure.org>"
 
 RUN apt-get update \
-  && apt-get install -y software-properties-common curl \
+  && apt-get install -y software-properties-common curl tzdata \
   && apt-get update \
   && apt-get install -y python3 python3-pip --no-install-recommends \
   && apt-get clean \

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,18 +4,11 @@
 FROM ubuntu:22.04 as buildstep
 LABEL maintainer="Richard Bullington-McGuire <richard@obscure.org>"
 
-RUN apt-get update
-
-RUN apt-get install -y software-properties-common
-
-RUN apt-get update
-
-RUN apt-get install -y python3-dev python3-pip curl build-essential git tzdata
+RUN apt-get update \
+  && DEBIAN_FRONTEND=noninteractive apt-get install -y python3-dev python3-pip curl build-essential git tzdata
 
 RUN mkdir -p /build/wheels
-
 RUN pip3 install --upgrade pip setuptools wheel
-
 ADD requirements.txt /tmp/requirements.txt
 RUN pip3 wheel -r /tmp/requirements.txt --wheel-dir=/build/wheels
 
@@ -25,7 +18,6 @@ WORKDIR /app
 
 RUN python3 setup.py bdist_wheel -d /build/wheels
 
-
 # DEPLOY
 # =====
 
@@ -33,13 +25,13 @@ FROM ubuntu:22.04 as deploystep
 LABEL maintainer="Richard Bullington-McGuire <richard@obscure.org>"
 
 RUN apt-get update \
-  && apt-get install -y software-properties-common curl tzdata \
+  && DEBIAN_FRONTEND=noninteractive apt-get install -y curl tzdata \
   && apt-get update \
-  && apt-get install -y python3 python3-pip --no-install-recommends \
+  && DEBIAN_FRONTEND=noninteractive apt-get install -y python3 python3-pip --no-install-recommends \
   && apt-get clean \
-  pip3 install --upgrade pip setuptools wheel \
   && rm -rf /var/lib/apt/lists/*
 
+RUN pip3 install --upgrade pip setuptools wheel
 RUN mkdir -p /data/cache/activities
 RUN mkdir -p /data/cache/weather
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get install -y software-properties-common
 
 RUN apt-get update
 
-RUN apt-get install -y python3-dev python3-pip curl build-essential git
+RUN apt-get install -y python3-dev python3-pip curl build-essential git tzdata
 
 RUN mkdir -p /build/wheels
 

--- a/freezing/sync/run.py
+++ b/freezing/sync/run.py
@@ -9,21 +9,8 @@ import arrow
 from apscheduler.schedulers.background import BackgroundScheduler
 from greenstalk import Client, TimedOutError
 
-# Monkeypatch collections to get Alembic to work
-# Adapted from MIT licensed code at:
-# https://github.com/healthvana/h2/commit/d67c6ca10eb7f79c0737c37fdecfe651307a7414
-# Thanks https://github.com/jazzband/django-push-notifications/issues/622#issuecomment-1234497703
-if sys.version_info.major >= 3 and sys.version_info.minor >= 10:
-    """
-    The alembic package is throwing errors because some aliases in collections were removed in 3.10.
-    """
-    import collections
-    from collections import abc
-    collections.Iterable = abc.Iterable
-    collections.Mapping = abc.Mapping
-    collections.MutableSet = abc.MutableSet
-    collections.MutableMapping = abc.MutableMapping
-
+from freezing.model.monkeypatch import collections
+collections()
 
 from freezing.model import init_model
 from freezing.model.msg.mq import DefinedTubes

--- a/freezing/sync/run.py
+++ b/freezing/sync/run.py
@@ -1,21 +1,12 @@
-import os
-import sys
-import threading
-import enum
-from functools import partial
-from datetime import datetime
-
 import arrow
+import threading
 from apscheduler.schedulers.background import BackgroundScheduler
-from greenstalk import Client, TimedOutError
-
-from freezing.model.monkeypatch import collections
-collections()
+from greenstalk import Client
 
 from freezing.model import init_model
 from freezing.model.msg.mq import DefinedTubes
 
-from freezing.sync.config import config, init_logging, statsd
+from freezing.sync.config import config, init_logging
 from freezing.sync.autolog import log
 
 # from freezing.sync.workflow import configured_publisher
@@ -40,10 +31,12 @@ def main():
     weather_sync = WeatherSync()
     athlete_sync = AthleteSync()
 
-    # Every hour run a sync on the activities for athletes fall into the specified segment
+    # Every hour run a sync on the activities for athletes
+    # falling into the specified segment
     # athlete_id % total_segments == segment
-    # TODO: Probably it would be more prudent to split into 15-minute segments, to match rate limits
-    # Admittedly that will make the time-based segment calculation a little trickier.
+    # TODO: Probably it would be more prudent to split into 15-minute segments,
+    # to match rate limits.  Admittedly that will make the time-based segment
+    # calculation a little trickier.
     def segmented_sync_activities():
         activity_sync.sync_rides_distributed(
             total_segments=4, segment=(arrow.now().hour % 4)
@@ -80,11 +73,12 @@ def main():
     shutdown_monitor.start()
 
     try:
-        # This is here to simulate application activity (which keeps the main thread alive).
+        # This is here to simulate application activity
+        # (which keeps the main thread alive).
         subscriber.run_forever()
     except (KeyboardInterrupt, SystemExit):
         log.info("Exiting on user request.")
-    except:
+    except Exception:
         log.exception("Error running sync/listener.")
     finally:
         shutdown_event.set()

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ PyMySQL==0.9.3
 colorlog==4.1.0
 datadog==0.33.0
 envparse==0.2.0
-freezing-model @ https://github.com/freezingsaddles/freezing-model/archive/0.7.16.tar.gz
+freezing-model @ https://github.com/freezingsaddles/freezing-model/archive/0.7.18.tar.gz
 greenstalk==1.0.1
 polyline==1.4.0
 pytz==2023.3.post1

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ PyMySQL==0.9.3
 colorlog==4.1.0
 datadog==0.33.0
 envparse==0.2.0
-freezing-model @ https://github.com/freezingsaddles/freezing-model/archive/0.7.18.tar.gz
+freezing-model @ https://github.com/freezingsaddles/freezing-model/archive/0.7.19.tar.gz
 greenstalk==1.0.1
 polyline==1.4.0
 pytz==2023.3.post1

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ PyMySQL==0.9.3
 colorlog==4.1.0
 datadog==0.33.0
 envparse==0.2.0
-freezing-model @ https://github.com/freezingsaddles/freezing-model/archive/0.6.3.tar.gz
+freezing-model @ https://github.com/freezingsaddles/freezing-model/archive/0.7.16.tar.gz
 greenstalk==1.0.1
 polyline==1.4.0
 pytz==2023.3.post1

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import os.path
 
 from setuptools import setup
 
-version = "1.4.1"
+version = "1.4.2"
 
 long_description = """
 freezing-sync is the component responsible for fetching activities, weather data, etc.

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import os.path
 
 from setuptools import setup
 
-version = "1.4.2"
+version = "1.4.3"
 
 long_description = """
 freezing-sync is the component responsible for fetching activities, weather data, etc.

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import os.path
 
 from setuptools import setup
 
-version = "1.4.3"
+version = "1.4.4"
 
 long_description = """
 freezing-sync is the component responsible for fetching activities, weather data, etc.

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import os.path
 
 from setuptools import setup
 
-version = "1.3.0"
+version = "1.4.1"
 
 long_description = """
 freezing-sync is the component responsible for fetching activities, weather data, etc.


### PR DESCRIPTION
Use the version of Freezing Model - 0.7.x - that has modern library updates and fixes to support them, to get Python 3.10 support.