### PR TITLE
Fix visual crossing precip

### DIFF
--- a/freezing/sync/wx/visualcrossing/model.py
+++ b/freezing/sync/wx/visualcrossing/model.py
@@ -17,7 +17,7 @@ class Hour(object):
         self.time = datetime.combine(date, time.fromisoformat(json["datetime"]).replace(tzinfo=tz))
         self.temperature = json["temp"]
         self.apparent_temperature = json["feelslike"]
-        precip_types = json.get("precipType", [])  # can be null
+        precip_types = json.get("preciptype", [])  # can be null
         # precip is rain plus melted snow which means if it snows then we have to overwrite this value
         # with the actual snowfall in order to avoid double-counting those molecules. we can't record a
         # ride as both rain and snow because then the ride rainfall would count instead the frozen snow
@@ -26,6 +26,10 @@ class Hour(object):
         if "snow" in precip_types:
             self.precip_type = "snow"
             self.precip_accumulation = json.get("snow", 0.0)
+        elif "sleet" in precip_types:
+            self.precip_type = "rain"  # count sleet as rain
+        elif "ice" in precip_types:
+            self.precip_type = "rain"  # count ice as rain
         elif "rain" in precip_types:
             self.precip_type = "rain"
         else:

--- a/freezing/sync/wx/visualcrossing/model.py
+++ b/freezing/sync/wx/visualcrossing/model.py
@@ -17,21 +17,17 @@ class Hour(object):
         self.time = datetime.combine(date, time.fromisoformat(json["datetime"]).replace(tzinfo=tz))
         self.temperature = json["temp"]
         self.apparent_temperature = json["feelslike"]
-        precip_types = json.get("preciptype", [])  # can be null
+        precip_types = json["preciptype"]  # can be null
         # precip is rain plus melted snow which means if it snows then we have to overwrite this value
         # with the actual snowfall in order to avoid double-counting those molecules. we can't record a
         # ride as both rain and snow because then the ride rainfall would count instead the frozen snow
         # accumulation and massively overstate reality. so snow always trumps rain.
         self.precip_accumulation = json.get("precip", 0.0)
-        if "snow" in precip_types:
+        if precip_types and "snow" in precip_types:
             self.precip_type = "snow"
             self.precip_accumulation = json.get("snow", 0.0)
-        elif "sleet" in precip_types:
-            self.precip_type = "rain"  # count sleet as rain
-        elif "ice" in precip_types:
-            self.precip_type = "rain"  # count ice as rain
-        elif "rain" in precip_types:
-            self.precip_type = "rain"
+        elif precip_types and ("sleet" in precip_types or "ice" in precip_types or "rain" in precip_types):
+            self.precip_type = "rain"  # count ice and sleet as rain
         else:
             self.precip_type = ""
         self.source = json["source"]


### PR DESCRIPTION
Visual Crossing changed the capitalisation in their dark sky clone. Also, count sleet and ice as rain. We have to count them this way because they are measured in their melted form.