### PR TITLE
Bump version for release, use deployed freezing-model

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ PyMySQL==0.9.3
 colorlog==4.1.0
 datadog==0.33.0
 envparse==0.2.0
-freezing-model @ https://github.com/freezingsaddles/freezing-model/archive/0.7.19.tar.gz
+freezing-model @ https://github.com/freezingsaddles/freezing-model/archive/0.7.20.tar.gz
 greenstalk==1.0.1
 polyline==1.4.0
 pytz==2023.3.post1

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import os.path
 
 from setuptools import setup
 
-version = "1.4.4"
+version = "1.4.7"
 
 long_description = """
 freezing-sync is the component responsible for fetching activities, weather data, etc.


### PR DESCRIPTION
This brings in the last change deployed last week