### PR TITLE
Fix default host for datadog, docker ignore .cfg

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -16,4 +16,5 @@ eggs/
 .eggs/
 *.egg-info/
 *.egg
+*.cfg
 

--- a/freezing/sync/config.py
+++ b/freezing/sync/config.py
@@ -59,7 +59,7 @@ class Config:
 
     DATADOG_API_KEY = env("DATADOG_API_KEY", default=None)
     DATADOG_APP_KEY = env("DATADOG_APP_KEY", default=None)
-    DATADOG_HOST = env("DATADOG_HOST", default="datadog.container")
+    DATADOG_HOST = env("DATADOG_HOST", default="localhost")
     DATADOG_PORT = env("DATADOG_PORT", cast=int, default=8125)
 
     REQUEUE_DELAY = env("REQUEUE_DELAY", cast=int, default=300)


### PR DESCRIPTION
This is super minor but a cleanup I did in other repos too