### PR TITLE
Fix docker compose in ssh

### DIFF
--- a/.github/workflows/build-latest.yml
+++ b/.github/workflows/build-latest.yml
@@ -34,5 +34,5 @@ jobs:
         script: |
           set -euo pipefail
           cd /opt/compose
-          docker-compose pull freezing-sync
-          docker-compose up -d freezing-sync
+          docker compose pull freezing-sync
+          docker compose up -d freezing-sync


### PR DESCRIPTION
This was failing given that we use `docker compose` instaead of the
alias `docker-compose` on the server now
