### PR TITLE
fix Docker entrypoint, rate limits and logs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,9 @@ VOLUME /data
 
 COPY --from=buildstep /build/wheels /tmp/wheels
 
-RUN pip3 install /tmp/wheels/*
+# Thanks https://stackoverflow.com/a/74634740/424301 for the tip on
+# using --use-deprecated=legacy-resolver
+RUN pip3 install --use-deprecated=legacy-resolver /tmp/wheels/*
 
 RUN mkdir /app
 ADD alembic.ini /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # BUILD
 # =====
 
-FROM ubuntu:22.04 as buildstep
+FROM ubuntu:22.04 AS buildstep
 LABEL maintainer="Richard Bullington-McGuire <richard@obscure.org>"
 
 RUN apt-get update \
@@ -46,4 +46,4 @@ ADD alembic.ini /app
 
 WORKDIR /app
 
-CMD freezing-sync
+CMD ['freezing-sync']

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,4 +46,4 @@ ADD alembic.ini /app
 
 WORKDIR /app
 
-CMD ['freezing-sync']
+CMD ["/bin/sh", "-c", "freezing-sync"]

--- a/freezing/sync/config.py
+++ b/freezing/sync/config.py
@@ -111,5 +111,12 @@ def init_logging(loglevel: int = logging.INFO, color: bool = False):
         else:
             l.setLevel(logging.INFO)
 
+    # This logger is very noisy and spits out WARNING level
+    # messages that are not very useful, such as:
+    # "WARNING  [stravalib.attributes.EntityAttribute] Unable to set attribute visibility on entity <Activity id=13209828474 name=None>"
+    # Silence it except for CRITICAL messages.
+
+    logging.getLogger("stravalib.attributes").setLevel(logging.CRITICAL)
+
 
 statsd = DogStatsd(host=config.DATADOG_HOST, port=config.DATADOG_PORT)

--- a/freezing/sync/subscribe.py
+++ b/freezing/sync/subscribe.py
@@ -25,6 +25,9 @@ class ActivityUpdateSubscriber:
         self.activity_sync = ActivitySync(self.logger)
         self.streams_sync = StreamSync(self.logger)
 
+        """Delay between requests to Strava API to avoid rate limiting."""
+        self._THROTTLE_DELAY = 3.0
+
     def handle_message(self, message: ActivityUpdate):
         self.logger.info("Processing activity update {}".format(message))
 
@@ -102,6 +105,9 @@ class ActivityUpdateSubscriber:
                         )  # We put it back with a delay
                     else:
                         self.client.delete(job)
+                        # FIXME: Work around stravalib 1.2's incomplete understanding of Strava Rate limits by just sleeping for a bit between requests.
+                        sleep(_THROTTLE_DELAY)
+
         except (KeyboardInterrupt, SystemExit):
             raise
         except:

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ PyMySQL==1.1.1
 colorlog==6.9.0
 datadog==0.50.2
 envparse==0.2.0
-freezing-model @ https://github.com/freezingsaddles/freezing-model/archive/0.10.4.tar.gz
+freezing-model @ https://github.com/freezingsaddles/freezing-model/archive/0.11.2.tar.gz
 greenstalk==2.0.2
 pytz==2024.2
 requests==2.32.3


### PR DESCRIPTION
- ** Fix Docker entrypoint **
- **Fend off rate limits, quiet noisy stravalib log**
 
Until we can tackle #45  and #64 upgrading Stravalib to a 2.x version  we need do do _something_ to improve our rate limit handling. This is a brute force approach.
