### PR TITLE
Fix project includes

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,0 @@
-recursive-include freezing/sync *

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,17 @@ inline-quotes = "double"
 
 [tool.setuptools]
 # Thanks https://stackoverflow.com/a/72547402/424301
-py-modules = ["freezing"]
+py-modules = [
+    "freezing.sync",
+    "freezing.sync.wx",
+    "freezing.sync.wx.ncdc",
+    "freezing.sync.wx.visualcrossing",
+    "freezing.sync.wx.darksky",
+    "freezing.sync.wx.wunder",
+    "freezing.sync.utils",
+    "freezing.sync.cli",
+    "freezing.sync.data",
+]
 
 
 [tool.djlint]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,20 +71,13 @@ max-complexity = 39
 extend-ignore = "E203"
 inline-quotes = "double"
 
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["freezing"]
+
 [tool.setuptools]
 # Thanks https://stackoverflow.com/a/72547402/424301
-py-modules = [
-    "freezing.sync",
-    "freezing.sync.wx",
-    "freezing.sync.wx.ncdc",
-    "freezing.sync.wx.visualcrossing",
-    "freezing.sync.wx.darksky",
-    "freezing.sync.wx.wunder",
-    "freezing.sync.utils",
-    "freezing.sync.cli",
-    "freezing.sync.data",
-]
-
+py-modules = []
 
 [tool.djlint]
 line_break_after_multiline_tag=true


### PR DESCRIPTION
After #82 we were getting `ModuleNotFoundError: No module named 'freezing.sync'` errors, this should fix it.