### PR TITLE
fix: wrap write_ride in no_autoflush to prevent FK violations on new rides

### DIFF
--- a/freezing/sync/data/activity.py
+++ b/freezing/sync/data/activity.py
@@ -712,80 +712,81 @@ class ActivitySync(BaseSync):
         :rtype: bafs.orm.Ride
         """
         session = meta.scoped_session()
-        if activity.start_latlng:
-            start_geo = WKTElement(
-                wktutils.point_wkt(activity.start_latlng.lon, activity.start_latlng.lat)
-            )
-        else:
-            start_geo = None
-
-        if activity.end_latlng:
-            end_geo = WKTElement(
-                wktutils.point_wkt(activity.end_latlng.lon, activity.end_latlng.lat)
-            )
-        else:
-            end_geo = None
-
-        athlete_id = activity.athlete.id
-
-        # Fail fast for invalid data (this can happen with manual-entry rides)
-        assert activity.elapsed_time is not None
-        assert activity.moving_time is not None
-        assert activity.distance is not None
-
-        # Find the model object for that athlete (or create if doesn't exist)
-        athlete = session.get(Athlete, athlete_id)
-        if not athlete:
-            # The athlete has to exist since otherwise we wouldn't be able to query their rides
-            raise ValueError(
-                "Somehow you are attempting to write rides for an athlete not found in the database."
-            )
-
-        if start_geo is not None or end_geo is not None:
-            ride_geo = RideGeo()
-            ride_geo.start_geo = start_geo
-            ride_geo.end_geo = end_geo
-            ride_geo.ride_id = activity.id
-            session.merge(ride_geo)
-
-        ride = session.get(Ride, activity.id)
-        new_ride = ride is None
-
-        if new_ride:
-            ride = Ride(activity.id)
-
-            # Set the "workflow flags".  These all default to False in the database.  The value of NULL means
-            # that the workflow flag does not apply (e.g. do not bother fetching this)
-
-            ride.detail_fetched = False  # Just to be explicit
-
-            ride.track_fetched = False
-
-            # update_ride_basic will do this anyway
-            if activity.total_photo_count > 0:
-                ride.photos_fetched = False
-
-            session.add(ride)
-
-        else:
-            # If ride has been cropped, we re-fetch it.
-            if round(ride.distance, 3) != round(
-                unit_helper.miles(activity.distance.quantity()).magnitude, 3
-            ):
-                self.logger.info(
-                    "Queing resync of details for activity {0!r}: "
-                    "distance mismatch ({1} != {2})".format(
-                        activity,
-                        ride.distance,
-                        unit_helper.miles(activity.distance.quantity().magnitude),
-                    )
+        with session.no_autoflush:
+            if activity.start_latlng:
+                start_geo = WKTElement(
+                    wktutils.point_wkt(activity.start_latlng.lon, activity.start_latlng.lat)
                 )
-                ride.detail_fetched = False
+            else:
+                start_geo = None
+
+            if activity.end_latlng:
+                end_geo = WKTElement(
+                    wktutils.point_wkt(activity.end_latlng.lon, activity.end_latlng.lat)
+                )
+            else:
+                end_geo = None
+
+            athlete_id = activity.athlete.id
+
+            # Fail fast for invalid data (this can happen with manual-entry rides)
+            assert activity.elapsed_time is not None
+            assert activity.moving_time is not None
+            assert activity.distance is not None
+
+            # Find the model object for that athlete (or create if doesn't exist)
+            athlete = session.get(Athlete, athlete_id)
+            if not athlete:
+                # The athlete has to exist since otherwise we wouldn't be able to query their rides
+                raise ValueError(
+                    "Somehow you are attempting to write rides for an athlete not found in the database."
+                )
+
+            if start_geo is not None or end_geo is not None:
+                ride_geo = RideGeo()
+                ride_geo.start_geo = start_geo
+                ride_geo.end_geo = end_geo
+                ride_geo.ride_id = activity.id
+                session.merge(ride_geo)
+
+            ride = session.get(Ride, activity.id)
+            new_ride = ride is None
+
+            if new_ride:
+                ride = Ride(activity.id)
+
+                # Set the "workflow flags".  These all default to False in the database.  The value of NULL means
+                # that the workflow flag does not apply (e.g. do not bother fetching this)
+
+                ride.detail_fetched = False  # Just to be explicit
+
                 ride.track_fetched = False
 
-        ride.athlete = athlete
+                # update_ride_basic will do this anyway
+                if activity.total_photo_count > 0:
+                    ride.photos_fetched = False
 
-        self.update_ride_basic(strava_activity=activity, ride=ride)
+                session.add(ride)
+
+            else:
+                # If ride has been cropped, we re-fetch it.
+                if round(ride.distance, 3) != round(
+                    unit_helper.miles(activity.distance.quantity()).magnitude, 3
+                ):
+                    self.logger.info(
+                        "Queing resync of details for activity {0!r}: "
+                        "distance mismatch ({1} != {2})".format(
+                            activity,
+                            ride.distance,
+                            unit_helper.miles(activity.distance.quantity().magnitude),
+                        )
+                    )
+                    ride.detail_fetched = False
+                    ride.track_fetched = False
+
+            ride.athlete = athlete
+
+            self.update_ride_basic(strava_activity=activity, ride=ride)
 
         if new_ride:
             statsd.histogram("strava.activity.distance", ride.distance)

--- a/freezing/sync/data/activity.py
+++ b/freezing/sync/data/activity.py
@@ -587,8 +587,7 @@ class ActivitySync(BaseSync):
         overlaps = (
             meta.scoped_session()
             .execute(
-                text(
-                    """
+                text("""
                       select R.id
                       from rides R
                       where R.athlete_id = :athlete_id
@@ -596,8 +595,7 @@ class ActivitySync(BaseSync):
                       and R.start_date <= :end_date
                       AND DATE_ADD(R.start_date, INTERVAL R.elapsed_time SECOND) >= :start_date
                       AND R.name not like '%#nooverlap%'
-                    """
-                ).bindparams(
+                    """).bindparams(
                     athlete_id=activity.athlete.id,
                     activity_id=activity.id,
                     start_date=activity.start_date_local + _overlap_ignore,
@@ -715,7 +713,9 @@ class ActivitySync(BaseSync):
         with session.no_autoflush:
             if activity.start_latlng:
                 start_geo = WKTElement(
-                    wktutils.point_wkt(activity.start_latlng.lon, activity.start_latlng.lat)
+                    wktutils.point_wkt(
+                        activity.start_latlng.lon, activity.start_latlng.lat
+                    )
                 )
             else:
                 start_geo = None

--- a/freezing/sync/data/activity.py
+++ b/freezing/sync/data/activity.py
@@ -587,7 +587,8 @@ class ActivitySync(BaseSync):
         overlaps = (
             meta.scoped_session()
             .execute(
-                text("""
+                text(
+                    """
                       select R.id
                       from rides R
                       where R.athlete_id = :athlete_id
@@ -595,7 +596,8 @@ class ActivitySync(BaseSync):
                       and R.start_date <= :end_date
                       AND DATE_ADD(R.start_date, INTERVAL R.elapsed_time SECOND) >= :start_date
                       AND R.name not like '%#nooverlap%'
-                    """).bindparams(
+                    """
+                ).bindparams(
                     athlete_id=activity.athlete.id,
                     activity_id=activity.id,
                     start_date=activity.start_date_local + _overlap_ignore,


### PR DESCRIPTION
## Problem

`session.merge(ride_geo)` and `session.get(Ride)` trigger SQLAlchemy autoflush, which tries to INSERT the ride before it is fully populated. This causes:

- FK constraint failures (`ride_geo` references `rides` which doesn't exist yet)
- NOT NULL violations (`athlete_id`, `elapsed_time`) on the new ride path

The result is silent ride-skip failures logged as `[ERROR] Unable to write ride (skipping)`.

## Impact

This affects every new athlete's first sync, and any athlete's first ride of a new season. In production the automated retry cycle masks the failure, but the first sync always silently drops rides.

Found while setting up a local dev environment and running `freezing-sync-activities` against a fresh database. With no existing rides, every activity hits the new-ride code path, which surfaces the autoflush timing issue that production rarely encounters.

## Fix

Wrap the body of `write_ride` in `with session.no_autoflush:` so SQLAlchemy defers flushing until all fields are set. The existing code ordering is preserved unchanged.

## Testing

Verified by syncing 278 rides for athlete 8673580 against a fresh local database — previously all 278 failed, now all 278 succeed.