### PR TITLE
fix: re-fetch geospatial track when ride distance changes on batch sync

### DIFF
--- a/freezing/sync/data/activity.py
+++ b/freezing/sync/data/activity.py
@@ -816,7 +816,8 @@ class ActivitySync(BaseSync):
 
         # Quickly filter out only the rides that are not in the database.
         returned_ride_ids = set([r.id for r in api_ride_entries])
-        stored_ride_ids = set([r.id for r in db_rides])
+        db_rides_by_id = {r.id: r for r in db_rides}
+        stored_ride_ids = set(db_rides_by_id.keys())
         # new_ride_ids = list(returned_ride_ids - stored_ride_ids)
         removed_ride_ids = list(stored_ride_ids - returned_ride_ids)
 
@@ -903,14 +904,31 @@ class ActivitySync(BaseSync):
                         ride_ids_needing_streams.append(ride.id)
 
             else:
-                self.logger.debug(
-                    "[SKIPPED EXISTING]: {id} {name!r} ({i}/{num}) ".format(
-                        id=strava_activity.id,
-                        name=strava_activity.name,
-                        i=i + 1,
-                        num=num_rides,
-                    )
+                ride = db_rides_by_id[strava_activity.id]
+                strava_miles = round(
+                    unit_helper.miles(strava_activity.distance.quantity()).magnitude, 3
                 )
+                if round(ride.distance, 3) != strava_miles:
+                    self.logger.info(
+                        "[DISTANCE CHANGED]: {id} {name!r} stored={stored} strava={strava}".format(
+                            id=strava_activity.id,
+                            name=strava_activity.name,
+                            stored=ride.distance,
+                            strava=strava_miles,
+                        )
+                    )
+                    ride.track_fetched = False
+                    ride.detail_fetched = False
+                    sess.commit()
+                else:
+                    self.logger.debug(
+                        "[SKIPPED EXISTING]: {id} {name!r} ({i}/{num}) ".format(
+                            id=strava_activity.id,
+                            name=strava_activity.name,
+                            i=i + 1,
+                            num=num_rides,
+                        )
+                    )
 
         # Remove any rides that are in the database for this athlete that were not in the returned list.
         if removed_ride_ids:


### PR DESCRIPTION
**Fixes #81**

## Problem

When a ride is edited on Strava (e.g. cropped to remove spurious GPS data), the batch sync path in `_sync_rides()` unconditionally skipped existing rides without checking whether the ride had changed. This meant `track_fetched` was never reset to `False`, so `sync_streams` would never re-fetch the updated GPS track — leaving the stale route on the map indefinitely.

## Fix

- Build a `db_rides_by_id` lookup dict before the loop so existing ride objects can be retrieved by ID
- In the `else` branch for existing rides, compare stored distance against current Strava distance
- If distance differs: log `[DISTANCE CHANGED]`, set `track_fetched = False` and `detail_fetched = False`, and commit — the next scheduled `sync_streams` run will re-fetch the corrected track
- If distance is unchanged: log `[SKIPPED EXISTING]` as before — no behavioral change for unedited rides

## Notes

The webhook path (`subscribe.py`) already handles real-time crop events correctly by always calling `fetch_and_store_activity_streams()` unconditionally. This fix is the safety net for cases where the webhook was missed or hit a race condition where Strava's API hadn't reflected the edit yet when the webhook was processed.

The webhook path (`subscribe.py`) already handles real-time crop events correctly by always calling `fetch_and_store_activity_streams()` unconditionally. This fix is the safety net for cases where the webhook was missed or hit a race condition where Strava's API hadn't reflected the edit yet when the webhook was processed.

A future optimization could narrow the DB query to only fetch rides whose IDs are in `returned_ride_ids`, avoiding loading all of an athlete's stored rides into memory. For the scale of Freezing Saddles athletes I don't think this is a concern, but it's worth noting as a follow-up refactor.

## Testing

Reviewed the `_sync_rides()` logic and traced both the new-ride and existing-ride code paths. The distance-check approach mirrors how `write_ride()` already handles distance changes internally. Full end-to-end testing would require a live Strava activity edit, which wasn't performed — but the logic follows the existing patterns in the codebase.