### PR TITLE
feat: log environment and version at startup

### DIFF
--- a/freezing/sync/config.py
+++ b/freezing/sync/config.py
@@ -63,6 +63,8 @@ class Config:
 
     REQUEUE_DELAY = env("REQUEUE_DELAY", cast=int, default=300)
 
+    ENVIRONMENT = env("ENVIRONMENT", default="development")
+
 
 config = Config()
 

--- a/freezing/sync/run.py
+++ b/freezing/sync/run.py
@@ -19,6 +19,18 @@ from freezing.sync.subscribe import ActivityUpdateSubscriber
 
 def main():
     init_logging()
+
+    try:
+        from importlib.metadata import version as pkg_version
+
+        app_version = pkg_version("freezing-sync")
+    except Exception:
+        app_version = "unknown"
+
+    log.info(
+        f"Starting freezing-sync version={app_version} environment={config.ENVIRONMENT}"
+    )
+
     init_model(config.SQLALCHEMY_URL)
 
     shutdown_event = threading.Event()


### PR DESCRIPTION
**Closes #14**

## Problem

`freezing-sync` logged nothing at startup, making it difficult to diagnose
issues from logs alone — you couldn't tell which version of the code was
running or which environment it was deployed in.

## Fix

- Added `ENVIRONMENT` to `Config` in `config.py`, reading from the
  `ENVIRONMENT` env var with a default of `"development"`. The
  `freezing-compose` stack already passes this variable to the sync
  container; this change makes `freezing-sync` actually read it.
- Added a startup log line in `run.py:main()` immediately after
  `init_logging()`: `Starting freezing-sync version={version} environment={environment}`
- Version is read from package metadata via `importlib.metadata` with a
  graceful fallback to `"unknown"` if the package isn't properly installed.

## Testing

Ran `freezing-sync` locally with dummy env vars. The startup log line appeared
correctly before the DB connection attempt:

`Starting freezing-sync version=1.6.0 environment=development`

Verified the `"development"` default fires when `ENVIRONMENT` is not set.

## Notes

The `ENVIRONMENT` variable has no default in `freezing-compose`, meaning
production deployments must set it explicitly. The `"development"` default
covers the local dev case where the compose stack isn't running.